### PR TITLE
Config AVS Data and fix allocation delay bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,35 @@ The Docker Compose setup includes the following services:
 - Node configurations are stored in `.nodes/configs/`.
 - Operator keys are stored in `.nodes/operator_keys/`.
 
+### BLS AVS Configuration File (config.json)
+
+The BLS AVS configuration is defined in `docker/eigenlayer/config.json` and controls the key parameters for the AVS:
+
+```json
+{
+    "quorum": {
+        "minimumStake": "1",
+        "maxOperatorCount": 32,
+        "kickBIPsOfOperatorStake": 10000,
+        "kickBIPsOfTotalStake": 100
+    },
+    "metadata": {
+        "uri": "metadataURI"
+    }
+}
+```
+
+Configuration options:
+
+- **Quorum Settings**:
+  - `minimumStake`: The minimum amount of stake (in wei) required for an operator to participate
+  - `maxOperatorCount`: The maximum number of operators allowed in the AVS (32 by default)
+  - `kickBIPsOfOperatorStake`: Percentage of an operator's stake that can be slashed (in basis points, 10000 = 100%)
+  - `kickBIPsOfTotalStake`: Percentage of total stake that can be slashed (in basis points, 100 = 1%)
+
+- **Metadata**:
+  - `uri`: The URI pointing to the AVS metadata
+
 ## Accessing the Services
 
 - Ethereum RPC: http://localhost:8545

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - .env
     volumes:
       - ./.nodes:/root/.nodes
+      - ./docker/eigenlayer/config.json:/bls-middleware/contracts/docker/eigenlayer/config.json
   
   signer:
     image: ghcr.io/layr-labs/cerberus:0.0.2

--- a/docker/eigenlayer/Dockerfile.eigenlayer
+++ b/docker/eigenlayer/Dockerfile.eigenlayer
@@ -9,8 +9,7 @@ USER root
 RUN apt update && apt install -y lsof jq tmux bash  
 COPY --from=go-builder /go/bin/eigenlayer /bin/
 COPY --from=go-builder /go/bin/grpcurl /bin/
-RUN git clone --recurse-submodules -b min-quorum-stake https://github.com/BreadchainCoop/bls-middleware.git
-COPY config.json /bls-middleware/contracts/docker/eigenlayer/config.json
+RUN git clone --recurse-submodules https://github.com/BreadchainCoop/bls-middleware.git
 RUN cd bls-middleware/contracts && forge build 
 WORKDIR /bls-middleware
 WORKDIR /

--- a/docker/eigenlayer/Dockerfile.eigenlayer
+++ b/docker/eigenlayer/Dockerfile.eigenlayer
@@ -9,7 +9,8 @@ USER root
 RUN apt update && apt install -y lsof jq tmux bash  
 COPY --from=go-builder /go/bin/eigenlayer /bin/
 COPY --from=go-builder /go/bin/grpcurl /bin/
-RUN git clone --recurse-submodules https://github.com/BreadchainCoop/bls-middleware.git
+RUN git clone --recurse-submodules -b min-quorum-stake https://github.com/BreadchainCoop/bls-middleware.git
+COPY config.json /bls-middleware/contracts/docker/eigenlayer/config.json
 RUN cd bls-middleware/contracts && forge build 
 WORKDIR /bls-middleware
 WORKDIR /

--- a/docker/eigenlayer/config.json
+++ b/docker/eigenlayer/config.json
@@ -1,0 +1,11 @@
+{
+    "quorum": {
+        "minimumStake": "1",
+        "maxOperatorCount": 32,
+        "kickBIPsOfOperatorStake": 10000,
+        "kickBIPsOfTotalStake": 100
+    },
+    "metadata": {
+        "uri": "metadataURI"
+    }
+} 

--- a/docker/eigenlayer/main.sh
+++ b/docker/eigenlayer/main.sh
@@ -50,8 +50,11 @@ if [ "$ENVIRONMENT" = "TESTNET" ]; then
     echo "Sleeping for 5 minutes to allow allocation delay to be processed on testnet..."
     sleep 360
 else 
-    echo "Sleeping for 180 seconds to allow allocation delay to be processed locally..."
-    sleep 180
+    echo "Using evm_increaseTime to advance blockchain time by 380 seconds..."
+    # Increase EVM time by 380 seconds
+    cast rpc evm_increaseTime 380 --rpc-url $RPC_URL > /dev/null 2>&1
+    # Mine a new block to apply the time change
+    cast rpc anvil_mine --rpc-url $RPC_URL > /dev/null 2>&1
 fi
 
 # deploy script 

--- a/docker/eigenlayer/main.sh
+++ b/docker/eigenlayer/main.sh
@@ -49,6 +49,9 @@ done
 if [ "$ENVIRONMENT" = "TESTNET" ]; then
     echo "Sleeping for 5 minutes to allow allocation delay to be processed on testnet..."
     sleep 360
+else 
+    echo "Sleeping for 180 seconds to allow allocation delay to be processed locally..."
+    sleep 180
 fi
 
 # deploy script 


### PR DESCRIPTION
Gives ability to config everything here

{
    "quorum": {
        "minimumStake": "1",
        "maxOperatorCount": 32,
        "kickBIPsOfOperatorStake": 10000,
        "kickBIPsOfTotalStake": 100
    },
    "metadata": {
        "uri": "metadataURI"
    }
}

also fixes the allocation delay error by adding 180 sec delay on local closes #5 

PR in other repo: https://github.com/BreadchainCoop/bls-middleware/pull/11
Note this PR references the specific branch in the docker file