### PR TITLE
Meaningfully configure operator ports through config

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,20 +61,49 @@ The BLS AVS configuration is defined in `docker/eigenlayer/config.json` and cont
     },
     "metadata": {
         "uri": "metadataURI"
+    },
+    "operators": {
+        "testacc1": {
+            "socketAddress": "127.0.0.1:3000"
+        },
+        "testacc2": {
+            "socketAddress": "127.0.0.1:3000"
+        },
+        "testacc3": {
+            "socketAddress": "127.0.0.1:3000"
+        }
     }
 }
 ```
 
-Configuration options:
+#### Configuration Options
 
-- **Quorum Settings**:
-  - `minimumStake`: The minimum amount of stake (in wei) required for an operator to participate
-  - `maxOperatorCount`: The maximum number of operators allowed in the AVS (32 by default)
-  - `kickBIPsOfOperatorStake`: Percentage of an operator's stake that can be slashed (in basis points, 10000 = 100%)
-  - `kickBIPsOfTotalStake`: Percentage of total stake that can be slashed (in basis points, 100 = 1%)
+##### Quorum Settings
+- `minimumStake`: The minimum amount of stake (in wei) required for an operator to participate in the AVS. This is the minimum amount of tokens an operator must stake to be considered active.
+- `maxOperatorCount`: The maximum number of operators allowed in the AVS. Default is 32. This limits the total number of operators that can participate in the service.
+- `kickBIPsOfOperatorStake`: The percentage of an operator's stake that can be slashed (in basis points). 10000 basis points = 100%. This determines how much of an operator's stake can be slashed if they misbehave.
+- `kickBIPsOfTotalStake`: The percentage of total stake that can be slashed (in basis points). 100 basis points = 1%. This sets the maximum amount of total stake that can be slashed across all operators.
 
-- **Metadata**:
-  - `uri`: The URI pointing to the AVS metadata
+##### Metadata
+- `uri`: The URI pointing to the AVS metadata. This should contain information about the AVS service, its purpose, and any relevant documentation.
+
+##### Operators
+- Each operator entry contains:
+  - `socketAddress`: The network address where the operator's node can be reached. Format should be `IP:PORT`.
+  - Multiple operators can be configured, each with their own unique identifier (e.g., "testacc1", "testacc2", etc.)
+
+#### Recommended Settings
+
+For a production environment:
+- `minimumStake`: Set based on your security requirements. Higher values ensure more committed operators.
+- `maxOperatorCount`: Adjust based on your network's capacity and decentralization goals.
+- `kickBIPsOfOperatorStake`: Typically set to 10000 (100%) to allow full slashing of misbehaving operators.
+- `kickBIPsOfTotalStake`: Set based on your risk tolerance. Lower values (e.g., 100 = 1%) provide more protection against mass slashing events.
+
+For a test environment:
+- You can use lower values for `minimumStake` to make testing easier
+- Keep `maxOperatorCount` small (e.g., 3-5) for testing purposes
+- Use test operator addresses with appropriate test network configurations
 
 ## Accessing the Services
 

--- a/docker/eigenlayer/Dockerfile.eigenlayer
+++ b/docker/eigenlayer/Dockerfile.eigenlayer
@@ -9,7 +9,7 @@ USER root
 RUN apt update && apt install -y lsof jq tmux bash  
 COPY --from=go-builder /go/bin/eigenlayer /bin/
 COPY --from=go-builder /go/bin/grpcurl /bin/
-RUN git clone --recurse-submodules https://github.com/BreadchainCoop/bls-middleware.git
+RUN git clone --recurse-submodules -b register-ip https://github.com/BreadchainCoop/bls-middleware.git
 RUN cd bls-middleware/contracts && forge build 
 WORKDIR /bls-middleware
 WORKDIR /

--- a/docker/eigenlayer/Dockerfile.eigenlayer
+++ b/docker/eigenlayer/Dockerfile.eigenlayer
@@ -9,7 +9,7 @@ USER root
 RUN apt update && apt install -y lsof jq tmux bash  
 COPY --from=go-builder /go/bin/eigenlayer /bin/
 COPY --from=go-builder /go/bin/grpcurl /bin/
-RUN git clone --recurse-submodules -b register-ip https://github.com/BreadchainCoop/bls-middleware.git
+RUN git clone --recurse-submodules https://github.com/BreadchainCoop/bls-middleware.git
 RUN cd bls-middleware/contracts && forge build 
 WORKDIR /bls-middleware
 WORKDIR /

--- a/docker/eigenlayer/config.json
+++ b/docker/eigenlayer/config.json
@@ -7,5 +7,16 @@
     },
     "metadata": {
         "uri": "metadataURI"
+    },
+    "operators": {
+        "testacc1": {
+            "socketAddress": "127.0.0.1:3000"
+        },
+        "testacc2": {
+            "socketAddress": "127.0.0.1:3000"
+        },
+        "testacc3": {
+            "socketAddress": "127.0.0.1:3000"
+        }
     }
 } 

--- a/docker/eigenlayer/main.sh
+++ b/docker/eigenlayer/main.sh
@@ -52,7 +52,7 @@ if [ "$ENVIRONMENT" = "TESTNET" ]; then
 else 
     echo "Using evm_increaseTime to advance blockchain time by 380 seconds..."
     # Increase EVM time by 380 seconds
-    cast rpc evm_increaseTime 380 --rpc-url $RPC_URL > /dev/null 2>&1
+    cast rpc evm_increaseTime 480 --rpc-url $RPC_URL > /dev/null 2>&1
     # Mine a new block to apply the time change
     cast rpc anvil_mine --rpc-url $RPC_URL > /dev/null 2>&1
 fi
@@ -110,6 +110,9 @@ for i in $(seq 1 $num_accounts); do
         echo "Error: Failed to extract private key from private.ecdsa.json for operator $i"
         exit 1
     fi
+    
+    # Set the operator ID for registration
+    export OPERATOR_ID="testacc${i}"
     
     forge script script/RegisterOperator.s.sol --rpc-url $RPC_URL --broadcast --private-key $OPERATOR_PRIVATE_KEY --isolate --slow --skip-simulation #> /dev/null 2>&1
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
Add operator ports to the config.json like this 

    "operators": {
        "testacc1": {
            "socketAddress": "127.0.0.1:3000"
        },
        "testacc2": {
            "socketAddress": "127.0.0.1:3000"
        },
        "testacc3": {
            "socketAddress": "127.0.0.1:3000"
        }
    }
    
 must match the number of test accounts in the env


Other PR https://github.com/BreadchainCoop/bls-middleware/pull/12

Note: Need to remove the specific branch from dockerfile once other PR is merged 

closes #4 