### PR TITLE
Require explicit `AvsServiceManagerWrapper` threshold config

### DIFF
--- a/docker/eigenlayer/main.sh
+++ b/docker/eigenlayer/main.sh
@@ -33,6 +33,18 @@ if [ "$ENVIRONMENT" = "TESTNET" ] && [ -z "$FUNDED_KEY" ]; then
   echo "Error: FUNDED_KEY is not set in the environment variables. This is required for testnet."
   exit 1
 fi
+if [ -z "$QUORUM_THRESHOLD" ]; then
+  echo "Error: QUORUM_THRESHOLD is not set in the environment variables."
+  exit 1
+fi
+if [ -z "$THRESHOLD_DENOMINATOR" ]; then
+  echo "Error: THRESHOLD_DENOMINATOR is not set in the environment variables."
+  exit 1
+fi
+if [ -z "$BLOCK_STALE_MEASURE" ]; then
+  echo "Error: BLOCK_STALE_MEASURE is not set in the environment variables."
+  exit 1
+fi
 
 # Use FOUNDRY_PRIVATE_KEY if PRIVATE_KEY is not set
 if [ -z "$PRIVATE_KEY" ]; then
@@ -138,6 +150,9 @@ if [ -z "$SERVICE_MANAGER_ADDRESS" ] || [ "$SERVICE_MANAGER_ADDRESS" = "null" ];
     exit 1
 fi
 export SERVICE_MANAGER_ADDRESS
+export QUORUM_THRESHOLD
+export THRESHOLD_DENOMINATOR
+export BLOCK_STALE_MEASURE
 
 cd /commonware-restaking-contracts
 forge script script/DeployAvsServiceManagerWrapper.s.sol:DeployAvsServiceManagerWrapper \

--- a/example.env
+++ b/example.env
@@ -49,6 +49,22 @@ CERBERUS_METRICS_PORT=9081
 SIGNER_ENDPOINT=http://signer:50051
 
 # =============================================================================
+# AVS Service Manager Wrapper Configuration
+# =============================================================================
+# These values are passed as immutable constructor parameters when deploying
+# AvsServiceManagerWrapper and CANNOT be changed after deployment.
+#
+# QUORUM_THRESHOLD / THRESHOLD_DENOMINATOR: fraction of total registered
+# operator stake that must sign a task for it to be accepted. 2/3 means at
+# least two-thirds of stake-weighted operators must co-sign.
+#
+# BLOCK_STALE_MEASURE: maximum age (in blocks) of a valid reference block.
+# At ~12 s/block on Ethereum, 300 blocks ≈ 1 hour.
+QUORUM_THRESHOLD=2
+THRESHOLD_DENOMINATOR=3
+BLOCK_STALE_MEASURE=300
+
+# =============================================================================
 # Debug Configuration (optional)
 # =============================================================================
 


### PR DESCRIPTION
## Summary

`QUORUM_THRESHOLD`, `THRESHOLD_DENOMINATOR`, and `BLOCK_STALE_MEASURE` are set as `immutable` in the `AvsServiceManagerWrapper` constructor — they cannot be changed after deployment. Previously `DeployAvsServiceManagerWrapper.s.sol` read these via `vm.envOr(...)`, silently using defaults (2, 3, 300) if unset.

- Adds all three vars to `example.env` with inline documentation explaining what each controls and that they are immutable post-deployment
- Adds explicit presence checks in `main.sh` alongside the other required-var guards so the script fails fast with a clear error rather than silently using forge's defaults
- Exports the three vars immediately before the `DeployAvsServiceManagerWrapper.s.sol` forge call so they are visible to the forge subprocess

Closes gas-killer/service#228