### PR TITLE
Pin "bls-middleware" clone to "v0.1" for reproducible builds

### DIFF
--- a/docker/eigenlayer/Dockerfile
+++ b/docker/eigenlayer/Dockerfile
@@ -36,7 +36,9 @@ COPY --from=go-builder /go/bin/grpcurl /usr/local/bin/
 COPY --from=go-builder /go/bin/blskeygen /usr/local/bin/
 
 # Clone and build BLS middleware contracts
-RUN git clone --recurse-submodules https://github.com/BreadchainCoop/bls-middleware.git
+# Pinned to a release tag for reproducible builds — bump the tag when upgrading bls-middleware.
+RUN git clone --branch v0.1 --depth 1 --recurse-submodules \
+    https://github.com/BreadchainCoop/bls-middleware.git
 
 # Clone commonware-restaking-contracts directly with all submodules
 RUN git clone --recurse-submodules https://github.com/BreadchainCoop/commonware-restaking-contracts.git


### PR DESCRIPTION
## Summary

- Pins the `bls-middleware` clone to tag `v0.1` instead of cloning HEAD, making Docker image builds reproducible
- Adds `--depth 1` for a shallow clone (faster builds, smaller image layer — full history is not needed)

## Context

Previously, every Docker build pulled whatever was at `bls-middleware` HEAD at build time. A change to bls-middleware could silently alter deployment behavior with no corresponding change in this repo. Pinning to a tagged release ensures the build is deterministic and upgrades are intentional.

To upgrade bls-middleware in future, bump the `--branch` value to the new tag.

Closes gas-killer/service#230