### PR TITLE
feat: deploy the Gas Killer ECDSA stack during AVS setup

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -10,6 +10,7 @@ on:
       - dev
   pull_request:
     branches:
+      - main
       - dev
   workflow_dispatch:
 
@@ -31,6 +32,7 @@ jobs:
           LST_CONTRACT_ADDRESS=0x00c71b0fcadE911B2feeE9912DE4Fe19eB04ca56
           LST_STRATEGY_ADDRESS=0x8b29d91e67b013e855EaFe0ad704aC4Ab086a574
           ALLOCATION_MANAGER_ADDRESS=0x42583067658071247ec8CE0A516A58f682002d07
+          AVS_DIRECTORY_ADDRESS=0xa789c91ECDdae96865913130B786140Ee17aF545
 
           # Network Configuration
           FORK_URL=https://ethereum-sepolia-rpc.publicnode.com
@@ -241,6 +243,45 @@ jobs:
           fi
           echo "  ✓ Contract code verified at stake registry (${#code_response} bytes)"
 
+          # Gas Killer ECDSA stack (deployed by main.sh; operators registered with it)
+          ecdsa_stake_registry=$(cat ./.nodes/avs_deploy.json | jq -r '.addresses.ecdsaStakeRegistry')
+          if [ -z "$ecdsa_stake_registry" ] || [ "$ecdsa_stake_registry" = "null" ]; then
+            echo "Error: ecdsaStakeRegistry address not found in deployment file"
+            cat ./.nodes/avs_deploy.json
+            exit 1
+          fi
+          echo "  ✓ ECDSA stake registry: $ecdsa_stake_registry"
+
+          gk_service_manager=$(cat ./.nodes/avs_deploy.json | jq -r '.addresses.gasKillerServiceManager')
+          if [ -z "$gk_service_manager" ] || [ "$gk_service_manager" = "null" ]; then
+            echo "Error: gasKillerServiceManager address not found in deployment file"
+            cat ./.nodes/avs_deploy.json
+            exit 1
+          fi
+          echo "  ✓ Gas Killer service manager: $gk_service_manager"
+
+          echo "Verifying contract code at ECDSA stake registry address..."
+          code_response=$(docker compose exec -T ethereum cast code "$ecdsa_stake_registry" --rpc-url http://localhost:8545 2>&1)
+          if [ "$code_response" = "0x" ] || [ -z "$code_response" ]; then
+            echo "Error: No contract code found at ECDSA stake registry address $ecdsa_stake_registry"
+            exit 1
+          fi
+          echo "  ✓ Contract code verified at ECDSA stake registry (${#code_response} bytes)"
+
+          echo "Verifying ECDSA operator registration + threshold..."
+          total_weight=$(docker compose exec -T ethereum cast call "$ecdsa_stake_registry" "getLastCheckpointTotalWeight()(uint256)" --rpc-url http://localhost:8545 | awk '{print $1}')
+          threshold_weight=$(docker compose exec -T ethereum cast call "$ecdsa_stake_registry" "getLastCheckpointThresholdWeight()(uint256)" --rpc-url http://localhost:8545 | awk '{print $1}')
+          echo "  ECDSA total weight: $total_weight, threshold: $threshold_weight"
+          if [ -z "$total_weight" ] || [ "$total_weight" = "0" ]; then
+            echo "Error: ECDSA stake registry has zero total weight (operators not registered)"
+            exit 1
+          fi
+          if [ -z "$threshold_weight" ] || [ "$threshold_weight" = "0" ]; then
+            echo "Error: ECDSA stake registry threshold was not finalized"
+            exit 1
+          fi
+          echo "  ✓ ECDSA operators registered and threshold finalized"
+
           echo "Deployment files validated successfully!"
 
       - name: Test Summary
@@ -255,6 +296,7 @@ jobs:
           echo "  ✓ EigenLayer setup completed"
           echo "  ✓ 3 BLS keys created and validated (all > 30 chars)"
           echo "  ✓ Deployment files created with verified contract code"
+          echo "  ✓ Gas Killer ECDSA stack deployed, operators registered, threshold set"
           echo ""
           echo "All tests passed successfully!"
 

--- a/docker/eigenlayer/Dockerfile
+++ b/docker/eigenlayer/Dockerfile
@@ -47,7 +47,7 @@ RUN git clone --recurse-submodules https://github.com/BreadchainCoop/commonware-
 # (EigenLayer ECDSAStakeRegistry via the eigenlayer-middleware submodule, the
 # GasKillerServiceManager, and the deploy/registration forge scripts main.sh runs).
 # Pinned to a commit for reproducible builds — bump when upgrading the stack.
-ARG GAS_KILLER_SERVICE_REF=28d99dca32928df502f47d937bea006868d0172a
+ARG GAS_KILLER_SERVICE_REF=1e3b7bed10a65b35b2a137e15c67f99ab83840b4
 RUN git clone https://github.com/gas-killer/service.git /gas-killer-service && \
     git -C /gas-killer-service checkout "${GAS_KILLER_SERVICE_REF}" && \
     git -C /gas-killer-service submodule update --init --recursive contracts/lib/eigenlayer-middleware && \

--- a/docker/eigenlayer/Dockerfile
+++ b/docker/eigenlayer/Dockerfile
@@ -43,6 +43,16 @@ RUN git clone --branch v0.1 --depth 1 --recurse-submodules \
 # Clone commonware-restaking-contracts directly with all submodules
 RUN git clone --recurse-submodules https://github.com/BreadchainCoop/commonware-restaking-contracts.git
 
+# Clone the Gas Killer service repo: contracts/ carries the ECDSA AVS stack
+# (EigenLayer ECDSAStakeRegistry via the eigenlayer-middleware submodule, the
+# GasKillerServiceManager, and the deploy/registration forge scripts main.sh runs).
+# Pinned to a commit for reproducible builds — bump when upgrading the stack.
+ARG GAS_KILLER_SERVICE_REF=28d99dca32928df502f47d937bea006868d0172a
+RUN git clone https://github.com/gas-killer/service.git /gas-killer-service && \
+    git -C /gas-killer-service checkout "${GAS_KILLER_SERVICE_REF}" && \
+    git -C /gas-killer-service submodule update --init --recursive contracts/lib/eigenlayer-middleware && \
+    cd /gas-killer-service/contracts && forge build
+
 # Set working directory to root (scripts handle navigation internally)
 WORKDIR /
 

--- a/docker/eigenlayer/main.sh
+++ b/docker/eigenlayer/main.sh
@@ -278,6 +278,8 @@ fi
 # their BLS middleware registration.
 echo "Deploying Gas Killer ECDSA stack (ECDSAStakeRegistry + GasKillerServiceManager)..."
 cd /gas-killer-service/contracts
+# forge's vm.writeJson does not create parent directories.
+mkdir -p "script/deployments/ecdsa-stack"
 forge script script/DeployECDSAStack.s.sol:DeployECDSAStack \
     --rpc-url "$RPC_URL"         \
     --private-key "$PRIVATE_KEY" \

--- a/docker/eigenlayer/main.sh
+++ b/docker/eigenlayer/main.sh
@@ -21,6 +21,10 @@ if [ -z "$STRATEGY_MANAGER_ADDRESS" ]; then
   echo "Error: STRATEGY_MANAGER_ADDRESS is not set in the environment variables."
   exit 1
 fi
+if [ -z "$AVS_DIRECTORY_ADDRESS" ]; then
+  echo "Error: AVS_DIRECTORY_ADDRESS is not set in the environment variables (required for the Gas Killer ECDSA stack)."
+  exit 1
+fi
 if [ -z "$RPC_URL" ]; then
   echo "Error: RPC_URL is not set in the environment variables."
   exit 1
@@ -268,6 +272,44 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+# Deploy the Gas Killer ECDSA stack: the EigenLayer ECDSAStakeRegistry that
+# verifies operator quorum signatures on-chain, plus the GasKillerServiceManager
+# wired to the AVSDirectory. Operators are registered with it below, right after
+# their BLS middleware registration.
+echo "Deploying Gas Killer ECDSA stack (ECDSAStakeRegistry + GasKillerServiceManager)..."
+cd /gas-killer-service/contracts
+forge script script/DeployECDSAStack.s.sol:DeployECDSAStack \
+    --rpc-url "$RPC_URL"         \
+    --private-key "$PRIVATE_KEY" \
+    --broadcast                  \
+    > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to deploy the Gas Killer ECDSA stack"
+    exit 1
+fi
+ECDSA_DEPLOY_JSON="/gas-killer-service/contracts/script/deployments/ecdsa-stack/$chain_id.json"
+if [ ! -f "$ECDSA_DEPLOY_JSON" ]; then
+    echo "Error: ECDSA stack deployment JSON not found at $ECDSA_DEPLOY_JSON"
+    exit 1
+fi
+ECDSA_STAKE_REGISTRY_ADDRESS=$(jq -r '.addresses.ecdsaStakeRegistry' "$ECDSA_DEPLOY_JSON")
+GAS_KILLER_SERVICE_MANAGER_ADDRESS=$(jq -r '.addresses.gasKillerServiceManager' "$ECDSA_DEPLOY_JSON")
+if [ -z "$ECDSA_STAKE_REGISTRY_ADDRESS" ] || [ "$ECDSA_STAKE_REGISTRY_ADDRESS" = "null" ] || \
+   [ -z "$GAS_KILLER_SERVICE_MANAGER_ADDRESS" ] || [ "$GAS_KILLER_SERVICE_MANAGER_ADDRESS" = "null" ]; then
+    echo "Error: Failed to read ECDSA stack addresses from $ECDSA_DEPLOY_JSON"
+    exit 1
+fi
+export ECDSA_STAKE_REGISTRY_ADDRESS
+export GAS_KILLER_SERVICE_MANAGER_ADDRESS
+echo "ECDSAStakeRegistry: $ECDSA_STAKE_REGISTRY_ADDRESS"
+echo "GasKillerServiceManager: $GAS_KILLER_SERVICE_MANAGER_ADDRESS"
+
+merged_json=$(jq -s '.[0] * .[1]' ~/.nodes/avs_deploy.json "$ECDSA_DEPLOY_JSON")
+echo "$merged_json" > ~/.nodes/avs_deploy.json
+echo "$merged_json" > /bls-middleware/contracts/avs_deploy.json
+
+cd /bls-middleware/contracts
+
 # On real networks (i.e. not anvil), EigenLayer enforces an ALLOCATION_CONFIGURATION_DELAY
 # (75 blocks on Sepolia, ~15 minutes). SetupMiddleware.s.sol calls modifyAllocations which creates
 # a *pending* allocation; registerForOperatorSets will revert with BelowMinimumStakeRequirement
@@ -379,13 +421,50 @@ for i in $(seq 1 $num_accounts); do
         echo "Error: Failed to register operator $OPERATOR_ADDRESS"
         exit 1
     fi
-    
+
+    # Register the operator with the Gas Killer ECDSAStakeRegistry (signing key =
+    # operator address; the AVSDirectory registration digest is signed in-script).
+    echo "Registering operator $OPERATOR_ADDRESS with the ECDSA stake registry..."
+    cd /gas-killer-service/contracts
+    forge script script/RegisterOperatorECDSA.s.sol:RegisterOperatorECDSA \
+        --rpc-url "$RPC_URL"                \
+        --private-key $OPERATOR_PRIVATE_KEY \
+        --isolate                           \
+        --slow                              \
+        --skip-simulation                   \
+        --broadcast                         \
+        > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to register operator $OPERATOR_ADDRESS with the ECDSA stake registry"
+        exit 1
+    fi
+    cd /bls-middleware/contracts
+
     WEIGHT=$(cast call $STAKE_REGISTRY "weightOfOperatorForQuorum(uint8,address)(uint96)" 0 $OPERATOR_ADDRESS --rpc-url $RPC_URL)
     if [ $? -ne 0 ]; then
         echo "Error: Failed to get operator weight for quorum for operator $i"
         exit 1
     fi
     echo "Operator $i weight in quorum 0: $WEIGHT"
+
+    ECDSA_WEIGHT=$(cast call $ECDSA_STAKE_REGISTRY_ADDRESS "getLastCheckpointOperatorWeight(address)(uint256)" $OPERATOR_ADDRESS --rpc-url $RPC_URL)
+    echo "Operator $i ECDSA stake registry weight: $ECDSA_WEIGHT"
 done
+
+# Set the ECDSA stake threshold now that all operators are registered
+echo "Finalizing Gas Killer ECDSA stake threshold..."
+cd /gas-killer-service/contracts
+forge script script/FinalizeECDSAStack.s.sol:FinalizeECDSAStack \
+    --rpc-url "$RPC_URL"         \
+    --private-key "$PRIVATE_KEY" \
+    --broadcast                  \
+    > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to finalize the ECDSA stake threshold"
+    exit 1
+fi
+cd /bls-middleware/contracts
+ECDSA_THRESHOLD=$(cast call $ECDSA_STAKE_REGISTRY_ADDRESS "getLastCheckpointThresholdWeight()(uint256)" --rpc-url $RPC_URL)
+echo "ECDSA stake registry threshold weight: $ECDSA_THRESHOLD"
 
 echo "Script execution finished. Container will now exit."


### PR DESCRIPTION
## Summary

Makes the setup image own the Gas Killer **ECDSA AVS** bootstrap end to end, so `avs_deploy.json` carries `ecdsaStakeRegistry` + `gasKillerServiceManager` from the start and operator registration happens where the operator keys already live (restoring the "setup container owns all AVS infra" pattern for the ECDSA migration).

- **Dockerfile**: clones `gas-killer/service` (pinned via `GAS_KILLER_SERVICE_REF`), whose `contracts/` carries EigenLayer's `ECDSAStakeRegistry` (eigenlayer-middleware v1.5.0 submodule), the `GasKillerServiceManager`, and the forge deploy/registration scripts; runs `forge build` in-image.
- **main.sh**: after `SetupMiddleware`, deploys the stack (`DeployECDSAStack`), registers every operator with an AVSDirectory-signed registration right after its BLS middleware registration (`RegisterOperatorECDSA`, runtime-derived salt so reruns never hit `SaltSpent`), then finalizes the stake threshold to `QUORUM_THRESHOLD/THRESHOLD_DENOMINATOR` of total weight (`FinalizeECDSAStack`), and merges the addresses into `avs_deploy.json`. Requires the new `AVS_DIRECTORY_ADDRESS`.
- **integration-test**: asserts the new addresses + on-chain code, non-zero total weight, and a finalized threshold; now also runs on PRs to `main`.

## Companion PR

Pairs with **gas-killer/service#309** (the ECDSA migration). This PR's build publishes `ghcr.io/breadchaincoop/eigenlayer:pr-ron-gas-killer-ecdsa-stack`, which that PR's E2E/Helm CI pulls. `GAS_KILLER_SERVICE_REF` is pinned to the validated service branch tip (`1e3b7be`).

**Merge order (corrected — service first):**
1. **Merge gas-killer/service#309 first.** Its E2E/Helm CI is pinned to this PR's `pr-ron-gas-killer-ecdsa-stack` image (already published), so it does not need this PR merged, and it stays independent of the mutable `:latest`.
2. **Bump `GAS_KILLER_SERVICE_REF`** in this PR's Dockerfile from the PR-branch commit (`1e3b7be`) to the **service `main` merge SHA** (the PR-branch commit becomes unreachable once #309's branch is deleted).
3. **Merge this PR (#38).** `:latest` is republished with the ECDSA stack — now matching service `main`, so other consumers of `:latest` are consistent.
4. **Service follow-up PR:** revert the migration-window pins back to `:latest` (`.github/workflows/e2e-test.yml`, `helm-integration-tests.yml`, `docker-compose.yml`, `helm/gas-killer/local-overrides.yaml`, `example.env`).

Why not infra-first: if `:latest` flips to the ECDSA image while service `main` is still BLS, every other service PR/main CI pulling `:latest` breaks (the new `main.sh` requires `AVS_DIRECTORY_ADDRESS` and writes an ECDSA `avs_deploy.json` a BLS codebase can't consume).

## Validation

Full docker-compose e2e green against a local build of this image (`currentSum` 0 → 1352): the container deploys the ECDSA stack + registers 3 operators via the real AVSDirectory + finalizes the threshold, and a live task's ECDSA quorum certificate executes on-chain through `ECDSAStakeRegistry.isValidSignature`.
